### PR TITLE
RC-81: revert Fly memory to 512mb after prod OOM

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -42,6 +42,6 @@ destination = "/home/node/.n8n"
 
 # Optional resources
 [vm]
-memory = "256mb"
+memory = "512mb"
 cpu_kind = "shared"
 cpus = 1


### PR DESCRIPTION
## What

- Revert `fly.toml` VM memory from `256mb` back to `512mb`.
- Keep production configuration aligned with the runtime rollback already applied in Fly.

## Why

- Production entered repeated OOM restarts on 256 MB (`exit_code=137`, `oom_killed=true`).
- Health check became critical until memory was scaled back to 512 MB.
- Without this PR, next deploy would reapply 256 MB and reintroduce instability.

## Jira

- Workspace/Board: `Running Coach` (`RC` / board `34`)
- Ticket: RC-81
- Epic: RC-10
- Sprint: RC Sprint 1
- Status transition checklist:
  - [x] moved to `In progress` when work started
  - [ ] moved to `In review` when PR opened
  - [ ] will move to `Done` after merge

## Scope

- [ ] Workflow logic (`workflows/*.json`)
- [x] Infrastructure / deploy (`Dockerfile`, `fly.toml`, GitHub Actions)
- [ ] Tests (`tests/*`)
- [ ] Docs

## Validation

- [x] Local checks performed
- [ ] Integration test run (`bash tests/run-it.sh`)
- [ ] CI passed

## Risks & Rollback

- Risk level: Low
- Main risks:
  - Slightly higher monthly cost versus 256 MB target.
- Rollback plan:
  - Re-apply 256 MB only after memory tuning and staged validation.

## Checklist

- [x] No secrets committed
- [x] Secret scan executed (`python3 scripts/scan_secrets.py`)
- [x] New/changed secrets are stored in secret manager (not in git) and reflected in `docs/secrets_management.md`
- [x] Backward compatibility considered
- [ ] README/docs updated if behavior changed
- [x] Branch follows `RC-<id>-<kebab-title>`
- [x] PR title follows `RC-<id>: short clear title`
- [x] Jira ticket is in `Running Coach` board (`RC` / board `34`)
