### PR TITLE
RC-83: add Grafana dashboard for Fly workflow metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ For complete rules, see:
 - Metric emitted by workflows: `running_coach_run_timestamp_seconds{workflow,status,env}` with `status=success|failure`.
 - Suggested Grafana/PromQL run count query:
   - `sum by (workflow,status) (changes(running_coach_run_timestamp_seconds[$__range]))`
+- Versioned Grafana dashboard JSON (Fly + Prometheus): `grafana/dashboards/running_coach_workflows.json`.
+- Import/setup guide: `docs/grafana_dashboard.md`.
 
 ## Data Lineage
 

--- a/docs/grafana_dashboard.md
+++ b/docs/grafana_dashboard.md
@@ -1,0 +1,33 @@
+# Grafana Dashboard (Fly + Pushgateway)
+
+This project ships a versioned Grafana dashboard for workflow telemetry:
+
+- `grafana/dashboards/running_coach_workflows.json`
+
+It uses the metric emitted by n8n workflows:
+
+- `running_coach_run_timestamp_seconds{workflow,status,env}`
+
+## Import in Grafana
+
+1. Open Grafana -> **Dashboards** -> **Import**.
+2. Upload `grafana/dashboards/running_coach_workflows.json`.
+3. Select your Prometheus datasource when prompted.
+4. Save.
+
+## Included panels
+
+- Total runs in selected range.
+- Successful runs in selected range.
+- Failed runs in selected range.
+- Success rate by workflow.
+- Run trend by workflow/status.
+- Last run timestamp by workflow/status.
+
+## Query model
+
+Because the metric value is a timestamp, run counts are derived with `changes(...)`:
+
+- `sum by (workflow,status) (changes(running_coach_run_timestamp_seconds[$__range]))`
+
+This allows counting executions without storing counters in MongoDB.

--- a/grafana/dashboards/running_coach_workflows.json
+++ b/grafana/dashboards/running_coach_workflows.json
@@ -1,0 +1,565 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "2.52.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(changes(running_coach_run_timestamp_seconds{env=~\"$env\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Runs (selected range)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(changes(running_coach_run_timestamp_seconds{status=\"success\",env=~\"$env\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Successful runs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(changes(running_coach_run_timestamp_seconds{status=\"failure\",env=~\"$env\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed runs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 98
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "displayMode": "basic",
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (workflow) (changes(running_coach_run_timestamp_seconds{status=\"success\",env=~\"$env\"}[$__range])) / clamp_min(sum by (workflow) (changes(running_coach_run_timestamp_seconds{env=~\"$env\"}[$__range])), 1)",
+          "instant": true,
+          "legendFormat": "{{workflow}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Success rate by workflow",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 14,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (workflow, status) (changes(running_coach_run_timestamp_seconds{env=~\"$env\"}[$__interval]))",
+          "legendFormat": "{{workflow}} / {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Runs over time by workflow and status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 14,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (workflow, status, env) (running_coach_run_timestamp_seconds{env=~\"$env\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Last run timestamp by workflow/status",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value #A": false
+            },
+            "renameByName": {
+              "Value #A": "last_run_timestamp"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "running-coach",
+    "n8n",
+    "fly",
+    "prometheus"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(running_coach_run_timestamp_seconds, env)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Environment",
+        "multi": false,
+        "name": "env",
+        "options": [],
+        "query": {
+          "query": "label_values(running_coach_run_timestamp_seconds, env)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Running Coach / Workflow Metrics",
+  "uid": "running-coach-workflow-metrics",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## What

- Add a versioned Grafana dashboard JSON for Running Coach workflow telemetry.
- Add import/setup documentation for Grafana + Prometheus datasource.
- Link the new dashboard/docs from the README observability section.

## Why

- We already emit `running_coach_run_timestamp_seconds{workflow,status,env}` to Pushgateway.
- Without a versioned dashboard, observability setup is manual and inconsistent.
- This makes dashboard import repeatable and tracked in git.

## Jira

- Workspace/Board: `Running Coach` (`RC` / board `34`)
- Ticket: RC-83
- Epic: RC-10
- Sprint: RC Sprint 1
- Status transition checklist:
  - [x] moved to `In progress` when work started
  - [x] moved to `In review` when PR opened
  - [ ] will move to `Done` after merge

## Scope

- [ ] Workflow logic (`workflows/*.json`)
- [ ] Infrastructure / deploy (`Dockerfile`, `fly.toml`, GitHub Actions)
- [ ] Tests (`tests/*`)
- [x] Docs

## Validation

- [x] Local checks performed
- [x] Integration test run (`bash tests/run-it.sh`)
- [ ] CI passed

## Risks & Rollback

- Risk level: Low
- Main risks:
  - PromQL panel queries may need small tuning depending on datasource scrape interval.
- Rollback plan:
  - Revert commit `RC-83` and re-import dashboards from previous version.

## Checklist

- [x] No secrets committed
- [x] Secret scan executed (`python3 scripts/scan_secrets.py`)
- [x] New/changed secrets are stored in secret manager (not in git) and reflected in `docs/secrets_management.md`
- [x] Backward compatibility considered
- [x] README/docs updated if behavior changed
- [x] Branch follows `RC-<id>-<kebab-title>`
- [x] PR title follows `RC-<id>: short clear title`
- [x] Jira ticket is in `Running Coach` board (`RC` / board `34`)
